### PR TITLE
specify local size for C row per work item case

### DIFF
--- a/Solutions/Exercise07/C/matmul.c
+++ b/Solutions/Exercise07/C/matmul.c
@@ -239,11 +239,12 @@ int main(int argc, char *argv[])
         // Execute the kernel over the rows of the C matrix ... computing
         // a dot product for each element of the product matrix.
         const size_t global = N;
+        const size_t local = ORDER / 16;
         err = clEnqueueNDRangeKernel(
             commands,
             kernel,
             1, NULL,
-            &global, NULL,
+            &global, &local,
             0, NULL, NULL);
         checkError(err, "Enqueueing kernel");
 

--- a/Solutions/Exercise07/Cpp/matmul.cpp
+++ b/Solutions/Exercise07/Cpp/matmul.cpp
@@ -168,7 +168,8 @@ int main(int argc, char *argv[])
             start_time = static_cast<double>(timer.getTimeMilliseconds()) / 1000.0;
 
             cl::NDRange global(N);
-            crow_mmul(cl::EnqueueArgs(queue, global),
+            cl::NDRange local(ORDER / 16);
+            crow_mmul(cl::EnqueueArgs(queue, global, local),
                     N, d_a, d_b, d_c);
 
             queue.finish();

--- a/Solutions/Exercise08/C/matmul.c
+++ b/Solutions/Exercise08/C/matmul.c
@@ -243,11 +243,12 @@ int main(int argc, char *argv[])
         // Execute the kernel over the rows of the C matrix ... computing
         // a dot product for each element of the product matrix.
         const size_t global = N;
+        const size_t local = ORDER / 16;
         err = clEnqueueNDRangeKernel(
             commands,
             kernel,
             1, NULL,
-            &global, NULL,
+            &global, &local,
             0, NULL, NULL);
         checkError(err, "Enqueueing kernel");
 

--- a/Solutions/Exercise08/Cpp/matmul.cpp
+++ b/Solutions/Exercise08/Cpp/matmul.cpp
@@ -168,7 +168,8 @@ int main(int argc, char *argv[])
             start_time = static_cast<double>(timer.getTimeMilliseconds()) / 1000.0;
 
             cl::NDRange global(N);
-            crow_mmul(cl::EnqueueArgs(queue, global),
+            cl::NDRange local(ORDER / 16);
+            crow_mmul(cl::EnqueueArgs(queue, global, local),
                     N, d_a, d_b, d_c);
 
             queue.finish();


### PR DESCRIPTION
For the solutions of "Understanding the OpenCL memory hierarchy" section, I suppose the local size should also be specified when enqueuing command for Matrix multiplication "C row per work item" case.