### PR TITLE
Remove OpenMP from the Makefile, not needed

### DIFF
--- a/Exercises/Exercise02/C/Makefile
+++ b/Exercises/Exercise02/C/Makefile
@@ -5,7 +5,7 @@ endif
 
 CCFLAGS=-O3 -lm
 
-LIBS = -lOpenCL -fopenmp
+LIBS = -lOpenCL
 
 COMMON_DIR = ../../C_common
 


### PR DESCRIPTION
If possible double check that it still works importing OpenMP, I wasn't able to.