### PR TITLE
Visual Studio 2017 support via CMake

### DIFF
--- a/Exercises/CMakeLists.txt
+++ b/Exercises/CMakeLists.txt
@@ -1,0 +1,87 @@
+cmake_minimum_required(VERSION 3.6)
+
+# Copyright (C) 2018 Paul Keir, University of the West of Scotland
+
+project(HOCL-Exercises)
+
+find_package(OpenCL REQUIRED)
+find_package(OpenMP REQUIRED)
+
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+set_property(GLOBAL PROPERTY PREDEFINED_TARGETS_FOLDER "_CMakePredefinedTargets")
+
+include_directories(${OpenCL_INCLUDE_DIRS} C_common Cpp_common)
+link_libraries(${OpenCL_LIBRARY})
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+
+set(name Exercise01)
+set(tname ${name}-Cpp)
+add_executable(${tname} ${name}/Cpp/DeviceInfo.cpp)
+set_target_properties(${tname} PROPERTIES FOLDER Cpp)
+
+set(name Exercise03)
+set(tname ${name}-Cpp)
+add_executable(${tname} ${name}/Cpp/vadd.cpp ${name}/Cpp/vadd.cl)
+target_compile_definitions(${tname} PRIVATE EX3_VADD_CL_PATH="../${name}/Cpp/vadd.cl")
+set_target_properties(${tname} PROPERTIES FOLDER Cpp)
+
+set(name Exercise04)
+set(tname ${name}-Cpp)
+add_executable(${tname} ${name}/Cpp/vadd.cpp ${name}/Cpp/vadd.cl)
+target_compile_definitions(${tname} PRIVATE EX4_VADD_CL_PATH="../${name}/Cpp/vadd.cl")
+set_target_properties(${tname} PROPERTIES FOLDER Cpp)
+
+set(name Exercise05)
+set(tname ${name}-Cpp)
+add_executable(${tname} ${name}/Cpp/vadd.cpp ${name}/Cpp/vadd.cl)
+target_compile_definitions(${tname} PRIVATE EX5_VADD_CL_PATH="../${name}/Cpp/vadd.cl")
+set_target_properties(${tname} PROPERTIES FOLDER Cpp)
+
+set(name Exercise06)
+set(tname ${name}-Cpp)
+add_executable(${tname} ${name}/Cpp/matmul.cpp ${name}/Cpp/matmul.hpp ${name}/Cpp/matrix_lib.cpp ${name}/Cpp/matrix_lib.hpp)
+set_target_properties(${tname} PROPERTIES FOLDER Cpp)
+
+set(name Exercise09)
+set(tname ${name}-Cpp)
+add_executable(${tname} ${name}/Cpp/pi.cpp)
+set_target_properties(${tname} PROPERTIES FOLDER Cpp)
+
+############################
+
+set(name Exercise01)
+set(tname ${name}-C)
+add_executable(${tname} ${name}/C/DeviceInfo.c)
+set_target_properties(${tname} PROPERTIES FOLDER C)
+
+set(name Exercise02)
+set(tname ${name}-C)
+add_executable(${tname} ${name}/C/vadd_c.c C_common/wtime.c C_common/device_info.c)
+set_target_properties(${tname} PROPERTIES FOLDER C)
+
+set(name Exercise04)
+set(tname ${name}-C)
+add_executable(${tname} ${name}/C/vadd_c.c C_common/wtime.c C_common/device_info.c)
+set_target_properties(${tname} PROPERTIES FOLDER C)
+
+set(name Exercise05)
+set(tname ${name}-C)
+add_executable(${tname} ${name}/C/vadd_c.c C_common/wtime.c C_common/device_info.c)
+set_target_properties(${tname} PROPERTIES FOLDER C)
+
+set(name Exercise06)
+set(tname ${name}-C)
+add_executable(${tname} ${name}/C/matmul.c ${name}/C/matmul.h ${name}/C/matrix_lib.c ${name}/C/matrix_lib.h C_common/wtime.c)
+set_target_properties(${tname} PROPERTIES FOLDER C)
+
+set(name Exercise09)
+set(tname ${name}-C)
+add_executable(${tname} ${name}/C/pi.c C_common/wtime.c)
+set_target_properties(${tname} PROPERTIES FOLDER C)
+
+set(name Exercise13)
+set(tname ${name}-C)
+add_executable(${tname} ${name}/C/gameoflife.c)
+set_target_properties(${tname} PROPERTIES FOLDER C)
+
+#set_property(DIRECTORY PROPERTY VS_STARTUP_PROJECT Exercise01-Cpp)

--- a/Exercises/Exercise01/C/DeviceInfo.c
+++ b/Exercises/Exercise01/C/DeviceInfo.c
@@ -34,7 +34,7 @@ int main(void)
         return EXIT_FAILURE;
     }
     // Create a list of platform IDs
-    cl_platform_id platform[num_platforms];
+    cl_platform_id *platform = malloc(num_platforms * sizeof(cl_platform_id));
     err = clGetPlatformIDs(num_platforms, platform, NULL);
     checkError(err, "Getting platforms");
 
@@ -66,7 +66,7 @@ int main(void)
         checkError(err, "Finding devices");
 
         // Get the device IDs
-        cl_device_id device[num_devices];
+        cl_device_id *device = malloc(num_devices * sizeof(cl_device_id));
         err = clGetDeviceIDs(platform[i], CL_DEVICE_TYPE_ALL, num_devices, device, NULL);
         checkError(err, "Getting devices");
         printf("Number of devices: %d\n", num_devices);
@@ -118,22 +118,25 @@ int main(void)
             err = clGetDeviceInfo(device[j], CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS, sizeof(cl_uint), &num, NULL);
             checkError(err, "Getting device max work-item dims");
             // Get the max. dimensions of the work-groups
-            size_t dims[num];
-            err = clGetDeviceInfo(device[j], CL_DEVICE_MAX_WORK_ITEM_SIZES, sizeof(dims), &dims, NULL);
+            size_t *dims = malloc(num * sizeof(size_t));
+            err = clGetDeviceInfo(device[j], CL_DEVICE_MAX_WORK_ITEM_SIZES, num * sizeof(size_t), dims, NULL);
             checkError(err, "Getting device max work-item sizes");
             printf("\t\tMax Work-group Dims: ( ");
             for (size_t k = 0; k < num; k++)
             {
                 printf("%ld ", dims[k]);
             }
-            printf(")\n");
 
+            free(dims);
+            printf(")\n");
             printf("\t-------------------------\n");
         }
 
+        free(device);
         printf("\n-------------------------\n");
     }
 
+    free(platform);
     return EXIT_SUCCESS;
 }
 

--- a/Exercises/Exercise01/Cpp/DeviceInfo.cpp
+++ b/Exercises/Exercise01/Cpp/DeviceInfo.cpp
@@ -10,7 +10,7 @@
 
 #define __CL_ENABLE_EXCEPTIONS
 
-#include "cl.hpp"
+#include "CL/cl.hpp"
 #include <iostream>
 #include <vector>
 

--- a/Exercises/Exercise02/C/vadd_c.c
+++ b/Exercises/Exercise02/C/vadd_c.c
@@ -15,6 +15,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>
+
 #ifdef __APPLE__
 #include <OpenCL/opencl.h>
 #include <unistd.h>
@@ -111,7 +112,7 @@ int main(int argc, char** argv)
     }
 
     // Get all platforms
-    cl_platform_id Platform[numPlatforms];
+    cl_platform_id *Platform = malloc(numPlatforms * sizeof(cl_platform_id));
     err = clGetPlatformIDs(numPlatforms, Platform, NULL);
     checkError(err, "Getting platforms");
 
@@ -124,6 +125,8 @@ int main(int argc, char** argv)
             break;
         }
     }
+
+    free(Platform);
 
     if (device_id == NULL)
         checkError(err, "Finding a device");

--- a/Exercises/Exercise03/Cpp/vadd.cpp
+++ b/Exercises/Exercise03/Cpp/vadd.cpp
@@ -15,7 +15,7 @@
 
 #define __CL_ENABLE_EXCEPTIONS
 
-#include "cl.hpp"
+#include "CL/cl.hpp"
 
 #include "util.hpp" // utility library
 
@@ -32,6 +32,11 @@
 // pick up device type from compiler command line or from the default type
 #ifndef DEVICE
 #define DEVICE CL_DEVICE_TYPE_DEFAULT
+#endif
+
+// Set the filepath if not already set
+#ifndef EX3_VADD_CL_PATH
+#define EX3_VADD_CL_PATH "vadd.cl"
 #endif
 
 //------------------------------------------------------------------------------
@@ -64,7 +69,7 @@ int main(void)
 
         // Load in kernel source, creating a program object for the context
 
-        cl::Program program(context, util::loadProgram("vadd.cl"), true);
+        cl::Program program(context, util::loadProgram(EX3_VADD_CL_PATH), true);
 
         // Get the command queue
         cl::CommandQueue queue(context);

--- a/Exercises/Exercise04/C/vadd_c.c
+++ b/Exercises/Exercise04/C/vadd_c.c
@@ -111,7 +111,7 @@ int main(int argc, char** argv)
     }
 
     // Get all platforms
-    cl_platform_id Platform[numPlatforms];
+    cl_platform_id *Platform = malloc(numPlatforms * sizeof(cl_platform_id));
     err = clGetPlatformIDs(numPlatforms, Platform, NULL);
     checkError(err, "Getting platforms");
 
@@ -124,6 +124,8 @@ int main(int argc, char** argv)
             break;
         }
     }
+
+    free(Platform);
 
     if (device_id == NULL)
         checkError(err, "Finding a device");

--- a/Exercises/Exercise04/Cpp/vadd.cpp
+++ b/Exercises/Exercise04/Cpp/vadd.cpp
@@ -15,7 +15,7 @@
 
 #define __CL_ENABLE_EXCEPTIONS
 
-#include "cl.hpp"
+#include "CL/cl.hpp"
 
 #include "util.hpp" // utility library
 
@@ -30,6 +30,11 @@
 // pick up device type from compiler command line or from the default type
 #ifndef DEVICE
 #define DEVICE CL_DEVICE_TYPE_DEFAULT
+#endif
+
+// Set the filepath if not already set
+#ifndef EX4_VADD_CL_PATH
+#define EX4_VADD_CL_PATH "vadd.cl"
 #endif
 
 #include <err_code.h>
@@ -64,7 +69,7 @@ int main(void)
 
         // Load in kernel source, creating a program object for the context
 
-        cl::Program program(context, util::loadProgram("vadd.cl"), true);
+        cl::Program program(context, util::loadProgram(EX4_VADD_CL_PATH), true);
 
         // Get the command queue
         cl::CommandQueue queue(context);

--- a/Exercises/Exercise05/C/vadd_c.c
+++ b/Exercises/Exercise05/C/vadd_c.c
@@ -111,7 +111,7 @@ int main(int argc, char** argv)
     }
 
     // Get all platforms
-    cl_platform_id Platform[numPlatforms];
+    cl_platform_id *Platform = malloc(numPlatforms * sizeof(cl_platform_id));
     err = clGetPlatformIDs(numPlatforms, Platform, NULL);
     checkError(err, "Getting platforms");
 
@@ -124,6 +124,8 @@ int main(int argc, char** argv)
             break;
         }
     }
+
+    free(Platform);
 
     if (device_id == NULL)
         checkError(err, "Finding a device");

--- a/Exercises/Exercise05/Cpp/vadd.cpp
+++ b/Exercises/Exercise05/Cpp/vadd.cpp
@@ -15,7 +15,7 @@
 
 #define __CL_ENABLE_EXCEPTIONS
 
-#include "cl.hpp"
+#include "CL/cl.hpp"
 
 #include "util.hpp" // utility library
 
@@ -32,6 +32,11 @@
 // pick up device type from compiler command line or from the default type
 #ifndef DEVICE
 #define DEVICE CL_DEVICE_TYPE_DEFAULT
+#endif
+
+// Set the filepath if not already set
+#ifndef EX5_VADD_CL_PATH
+#define EX5_VADD_CL_PATH "vadd.cl"
 #endif
 
 //------------------------------------------------------------------------------
@@ -64,7 +69,7 @@ int main(void)
 
         // Load in kernel source, creating a program object for the context
 
-        cl::Program program(context, util::loadProgram("vadd.cl"), true);
+        cl::Program program(context, util::loadProgram(EX5_VADD_CL_PATH), true);
 
         // Get the command queue
         cl::CommandQueue queue(context);

--- a/Exercises/Exercise13/C/gameoflife.c
+++ b/Exercises/Exercise13/C/gameoflife.c
@@ -44,9 +44,9 @@ void accelerate_life(const char* tick, char* tock, const int nx, const int ny)
     // wrapping around if required
     unsigned int x_l, x_r, y_u, y_d;
 
-    unsigned int j;
+    int i, j;
     #pragma omp parallel for private(j, idx, x_l, x_r, y_u, y_d)
-    for (unsigned int i = 0; i < ny; i++)
+    for (i = 0; i < ny; i++)
     {
         for (j = 0; j < nx; j++)
         {
@@ -101,11 +101,11 @@ void accelerate_life(const char* tick, char* tock, const int nx, const int ny)
 
 int main(int argc, char **argv)
 {
-
     // Check we have a starting state file
     if (argc != 3)
     {
         printf("Usage:\n./gameoflife input.dat input.params\n");
+        // ./gameoflife ../Exercise13/Examples/Acorn/acorn.dat ../Exercise13/Examples/Acorn/input.params
         return EXIT_FAILURE;
     }
 

--- a/Exercises/Exercise13/README.md
+++ b/Exercises/Exercise13/README.md
@@ -8,8 +8,8 @@ Goal
 Procedure
 ---------
 * Examine the CUDA kernel and identify which parts need changing
-    * Change them to the OpenCL equivalents
-* Examine the Host code and part the commands to the OpenCL equivalents
+* Change them to the OpenCL equivalents
+* Examine the Host code and port the commands to the OpenCL equivalents
 
 Expected output
 ---------------

--- a/Solutions/C_common/device_info.c
+++ b/Solutions/C_common/device_info.c
@@ -15,7 +15,6 @@
 #include <stdlib.h>
 #include <string.h>
 #ifdef __APPLE__
-
 #include <OpenCL/opencl.h>
 #else
 #include <CL/cl.h>


### PR DESCRIPTION
Changes to add Visual Studio 2017 support via CMake. This required using malloc instead of variable sized arrays (alloca support is also absent in MSVC btw.), and specifying paths to resource files differently; when building with CMake. MSVC is also fussy about OpenMP for loop induction variable declarations.